### PR TITLE
Reduced two steps to one

### DIFF
--- a/tasks/dnf-upgrade.yml
+++ b/tasks/dnf-upgrade.yml
@@ -1,11 +1,7 @@
 ---
-- name: Resynchronize dnf package index
-  become: yes
-  dnf:
-    update_cache: yes
-
 - name: Upgrade dnf packages
   become: yes
   dnf:
     name: '*'
     state: latest
+    update_cache: yes


### PR DESCRIPTION
ansible can update the dnf cache and update the system in the same command, reducing overall ansible runtime.